### PR TITLE
New splitBy function.  Directory listing functions.

### DIFF
--- a/app/App/Commands.hs
+++ b/app/App/Commands.hs
@@ -1,7 +1,8 @@
 module App.Commands where
 
 import App.Commands.Cp
-import Data.Semigroup      ((<>))
+import App.Commands.LsPrefix
+import Data.Semigroup        ((<>))
 import Options.Applicative
 
 commands :: Parser (IO ())
@@ -11,3 +12,4 @@ commandsGeneral :: Parser (IO ())
 commandsGeneral = subparser $ mempty
   <>  commandGroup "Commands:"
   <>  cmdCp
+  <>  cmdLsPrefix

--- a/app/App/Commands/LsPrefix.hs
+++ b/app/App/Commands/LsPrefix.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
+
+module App.Commands.LsPrefix
+  ( cmdLsPrefix
+  ) where
+
+import Antiope.Core                   (Region (..))
+import Antiope.Env                    (mkEnv)
+import Antiope.Options.Applicative
+import App.Show
+import Control.Lens
+import Control.Monad.Except
+import Control.Monad.Trans.Resource   (runResourceT)
+import Data.Generics.Product.Any
+import Data.Semigroup                 ((<>))
+import HaskellWorks.Data.Uri.Location
+import HaskellWorks.Data.Uri.UriError (displayUriError)
+import Options.Applicative            hiding (columns)
+
+import qualified App.Aws.Logger                as AWS
+import qualified App.Commands.Types            as Z
+import qualified Data.Text                     as T
+import qualified Data.Text.IO                  as TIO
+import qualified HaskellWorks.Data.Uri.IO.Lazy as URI
+import qualified System.IO                     as IO
+import qualified System.IO.Unsafe              as IO
+
+runLsPrefix :: Z.LsPrefixOptions -> IO ()
+runLsPrefix opts = do
+  let prefix       = opts ^. the @"prefix"
+  let region      = opts ^. the @"region"
+  let awsLogLevel = opts ^. the @"awsLogLevel"
+
+  envAws <- IO.unsafeInterleaveIO $ mkEnv region (AWS.awsLogger awsLogLevel)
+
+  result <- runResourceT . runExceptT $ do
+    locations <- URI.listResourcePrefix envAws prefix
+    forM_ locations $ \location -> liftIO $ TIO.putStrLn (tshow location)
+
+    return ()
+
+  case result of
+    Right _  -> return ()
+    Left msg -> TIO.hPutStrLn IO.stderr (displayUriError msg)
+
+optsLsPrefix :: Parser Z.LsPrefixOptions
+optsLsPrefix = Z.LsPrefixOptions
+  <$> option (maybeReader (toLocation . T.pack))
+        (   long "prefix"
+        <>  short 'p'
+        <>  help "Prefix location"
+        <>  metavar "LOCATION"
+        )
+  <*> option auto
+      (  long "region"
+      <> metavar "AWS_REGION"
+      <> showDefault <> value Oregon
+      <> help "The AWS region in which to operate"
+      )
+  <*> optional
+      ( option autoText
+        (   long "aws-log-level"
+        <>  help "AWS Log Level.  One of (Error, Info, Debug, Trace)"
+        <>  metavar "AWS_LOG_LEVEL"
+        )
+      )
+
+cmdLsPrefix :: Mod CommandFields (IO ())
+cmdLsPrefix = command "ls-prefix"  $ flip info idm $ runLsPrefix <$> optsLsPrefix

--- a/app/App/Commands/Types.hs
+++ b/app/App/Commands/Types.hs
@@ -3,6 +3,7 @@
 
 module App.Commands.Types
   ( CpOptions(..)
+  , LsPrefixOptions(..)
   ) where
 
 import Antiope.Env                    (Region)
@@ -14,6 +15,12 @@ import qualified Antiope.Env as AWS
 data CpOptions = CpOptions
   { input       :: Location
   , output      :: Location
+  , region      :: Region
+  , awsLogLevel :: Maybe AWS.LogLevel
+  } deriving (Eq, Show, Generic)
+
+data LsPrefixOptions = LsPrefixOptions
+  { prefix      :: Location
   , region      :: Region
   , awsLogLevel :: Maybe AWS.LogLevel
   } deriving (Eq, Show, Generic)

--- a/hw-uri.cabal
+++ b/hw-uri.cabal
@@ -23,8 +23,8 @@ common aeson                          { build-depends: aeson                    
 common amazonka                       { build-depends: amazonka                       >= 1.6.1      && < 1.7    }
 common amazonka-core                  { build-depends: amazonka-core                  >= 1.6.1      && < 1.7    }
 common amazonka-s3                    { build-depends: amazonka-s3                    >= 1.6.1      && < 1.7    }
-common antiope-core                   { build-depends: antiope-core                   >= 7.3.3      && < 8      }
-common antiope-s3                     { build-depends: antiope-s3                     >= 7.3.3      && < 8      }
+common antiope-core                   { build-depends: antiope-core                   >= 7.4.2      && < 8      }
+common antiope-s3                     { build-depends: antiope-s3                     >= 7.4.2      && < 8      }
 common antiope-optparse-applicative   { build-depends: antiope-optparse-applicative   >= 7.0.1      && < 8      }
 common bytestring                     { build-depends: bytestring                     >= 0.10.8.2   && < 0.11   }
 common directory                      { build-depends: directory                      >= 1.3.3.0    && < 1.4    }
@@ -36,9 +36,11 @@ common hspec                          { build-depends: hspec                    
 common http-client                    { build-depends: http-client                    >= 0.5.14     && < 0.7    }
 common http-types                     { build-depends: http-types                     >= 0.12.3     && < 0.13   }
 common hw-hspec-hedgehog              { build-depends: hw-hspec-hedgehog              >= 0.1.0.4    && < 0.2    }
+common hw-prim                        { build-depends: hw-prim                        >= 0.6.2.33   && < 0.7    }
 common lens                           { build-depends: lens                           >= 4.17       && < 5      }
 common mtl                            { build-depends: mtl                            >= 2.2.2      && < 2.3    }
 common optparse-applicative           { build-depends: optparse-applicative           >= 0.14       && < 0.16   }
+common unliftio-core                  { build-depends: unliftio-core                  >= 0.1.2.0    && < 0.2    }
 common resourcet                      { build-depends: resourcet                      >= 1.2.2      && < 1.3    }
 common text                           { build-depends: text                           >= 1.2.3.1    && < 1.3    }
 
@@ -61,10 +63,12 @@ library
                       , generic-lens
                       , http-client
                       , http-types
+                      , hw-prim
                       , lens
                       , mtl
                       , resourcet
                       , text
+                      , unliftio-core
   other-modules:        Paths_hw_uri
   autogen-modules:      Paths_hw_uri
   hs-source-dirs:       src
@@ -99,6 +103,7 @@ executable hw-uri
   other-modules:        App.Aws.Logger
                         App.Commands
                         App.Commands.Cp
+                        App.Commands.LsPrefix
                         App.Commands.Types
                         App.Show
 
@@ -123,4 +128,5 @@ test-suite hw-uri-test
   build-tool-depends:   hspec-discover:hspec-discover
   other-modules:        HaskellWorks.Data.Uri.Gen
                         HaskellWorks.Data.Uri.AwsSpec
+                        HaskellWorks.Data.Uri.Internal.ListSpec
                         HaskellWorks.Data.Uri.LocationSpec

--- a/src/HaskellWorks/Data/Uri/IO/File.hs
+++ b/src/HaskellWorks/Data/Uri/IO/File.hs
@@ -1,16 +1,61 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module HaskellWorks.Data.Uri.IO.File
-  ( listMaybeDirectory
+  ( dirname
+  , listMaybeDirectory
+  , listFilesRecursiveWithPrefix
+  , listDirectory
+  , listFilesRecursive
   ) where
 
 import Control.Monad.Except
+import Control.Monad.IO.Unlift
+import Data.Semigroup          ((<>))
+import System.FilePath
 
-import qualified System.Directory as IO
+import qualified Data.List                           as L
+import qualified HaskellWorks.Control.Monad.Lazy     as IO
+import qualified HaskellWorks.Data.Uri.Internal.List as L
+import qualified System.Directory                    as IO
+
+dirname :: FilePath -> FilePath
+dirname filePath = case reverse (L.splitBy (== '/') ("$" <> filePath)) of
+  []  -> filePath
+  [_] -> filePath
+  bs  -> drop 1 (L.intercalate "/" (reverse (drop 1 bs)))
 
 listMaybeDirectory :: MonadIO m => FilePath -> m [FilePath]
 listMaybeDirectory filepath = do
   exists <- liftIO $ IO.doesDirectoryExist filepath
   if exists
-    then liftIO $ IO.listDirectory filepath
+    then listDirectory filepath
     else return []
+
+listDirectory :: MonadIO m => FilePath -> m [FilePath]
+listDirectory = liftIO . IO.listDirectory
+
+listFilesRecursive :: (MonadIO m, MonadUnliftIO m) => FilePath -> m [FilePath]
+listFilesRecursive filePath = do
+  ps <- listDirectory filePath
+  qs <- fmap concat $ IO.interleaveSequenceM $ fmap (recurse filePath) ps
+  let rs = if filePath /= "." then fmap (filePath </>) qs else qs
+  return rs
+
+recurse :: (MonadIO m, MonadUnliftIO m) => FilePath -> FilePath -> m [FilePath]
+recurse filePath p = do
+  isDirectory <- liftIO $ IO.doesDirectoryExist (filePath </> p)
+  if isDirectory
+    then case filePath </> p of
+      subPath -> if "./" `L.isPrefixOf` subPath
+        then listFilesRecursive (drop 2 subPath)
+        else listFilesRecursive subPath
+    else return [p]
+
+listFilesRecursiveWithPrefix :: (MonadIO m, MonadUnliftIO m) => FilePath -> m [FilePath]
+listFilesRecursiveWithPrefix prefix = if '/' `elem` prefix
+  then do
+    fs <- listFilesRecursive (dirname prefix)
+    return (filter (prefix `L.isPrefixOf`) fs)
+  else do
+    fs <- listFilesRecursive "."
+    return (filter (prefix `L.isPrefixOf`) fs)

--- a/src/HaskellWorks/Data/Uri/Internal/List.hs
+++ b/src/HaskellWorks/Data/Uri/Internal/List.hs
@@ -1,6 +1,7 @@
 module HaskellWorks.Data.Uri.Internal.List
   ( mapLast
   , dropSave1
+  , splitBy
   ) where
 
 mapLast :: (a -> a) -> [a] -> [a]
@@ -12,3 +13,7 @@ dropSave1 :: [a] -> [a]
 dropSave1 [x]    = [x]
 dropSave1 (_:xs) = xs
 dropSave1 []     = []
+
+splitBy :: (a -> Bool) -> [a] -> [[a]]
+splitBy p as = if null as then [] else go as
+  where go bs = let (cs, ds) = break p bs in cs:if null ds then [] else go (drop 1 ds)

--- a/test/HaskellWorks/Data/Uri/Internal/ListSpec.hs
+++ b/test/HaskellWorks/Data/Uri/Internal/ListSpec.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module HaskellWorks.Data.Uri.Internal.ListSpec
+  ( spec
+  ) where
+
+import Control.Monad
+import HaskellWorks.Hspec.Hedgehog
+import Hedgehog
+import Test.Hspec
+
+import qualified Data.List                           as L
+import qualified HaskellWorks.Data.Uri.Internal.List as L
+import qualified Hedgehog.Gen                        as G
+import qualified Hedgehog.Range                      as R
+
+{-# ANN module ("HLint: ignore Redundant do"        :: String) #-}
+{-# ANN module ("HLint: ignore Reduce duplication"  :: String) #-}
+{-# ANN module ("HLint: ignore Redundant bracket"   :: String) #-}
+
+spec :: Spec
+spec = describe "HaskellWorks.Data.Uri.Internal.ListSpec" $ do
+  it "splitBy" $ requireProperty $ do
+    as <- forAll $ G.list (R.linear 1 3) (G.string (R.linear 0 3) G.alpha)
+    when (as /= [""]) $ do
+      annotateShow $ L.intercalate "/" as
+      annotateShow $ L.splitBy (== '/') $ L.intercalate "/" as
+      L.splitBy (== '/') (L.intercalate "/" as) === as


### PR DESCRIPTION
Example:

```
λ> IO.listFilesRecursiveWithPrefix "/Users/jky/wrk/haskell-works/hw-uri/src/"
["/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Text.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/UriError.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Location.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Static.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/File.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Lazy.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Error.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Console.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Internal/Text.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Internal/List.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Show.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/AWS/Env.hs"]
λ> IO.listFilesRecursiveWithPrefix "/Users/jky/wrk/haskell-works/hw-uri/s"
["/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Text.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/UriError.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Location.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Static.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/File.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Lazy.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Error.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/IO/Console.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Internal/Text.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Internal/List.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/Show.hs","/Users/jky/wrk/haskell-works/hw-uri/src/HaskellWorks/Data/Uri/AWS/Env.hs"]
```

Command line examples:

```
~/wrk/haskell-works/hw-uri on list-resources!$ cabal v2-exec hw-uri -- ls-prefix --region Oregon --prefix sr
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/Text.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/UriError.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/Location.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/IO/Static.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/IO/File.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/IO/Lazy.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/IO/Error.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/IO/Console.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/Internal/Text.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/Internal/List.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/Show.hs"
Local "src/src/HaskellWorks/src/HaskellWorks/Data/src/HaskellWorks/Data/Uri/src/HaskellWorks/Data/Uri/AWS/Env.hs"
~/wrk/haskell-works/hw-uri on list-resources!$ cabal v2-exec hw-uri -- ls-prefix --region Oregon --prefix s3://jky-mayhem/vide
S3 (S3Uri {bucket = BucketName "jky-mayhem", objectKey = ObjectKey "videos/fp/introduction/episode-0.mp4"})
S3 (S3Uri {bucket = BucketName "jky-mayhem", objectKey = ObjectKey "videos/haskell-workshop/koans/simple-0.mp4"})
```